### PR TITLE
fix(auth): 애플 로그인 404 수정 (308 → 303) 및 소셜 로그인 실패 시 500 남발 정리

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -7,6 +7,7 @@ import {
   InternalServerErrorException,
   NotAcceptableException,
   Res,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import axios, { HttpStatusCode } from 'axios';
@@ -55,7 +56,11 @@ export class AuthService {
     try {
       response1 = await axios.post(apiUrl, body, { headers: header });
     } catch (error) {
-      throw new Error('카카오 토큰 발급 실패');
+      // 클라이언트가 준 인가코드가 무효/만료/이미 사용됨 → 서버 장애가 아니다.
+      // 500을 던지면 사용자에게 "Internal server error"가 그대로 노출되고 모니터링 알림도 오염된다.
+      throw new UnauthorizedException(
+        '유효하지 않거나 만료된 카카오 인가코드입니다.',
+      );
     }
 
     // <-> Kakao API / 토큰으로 사용자 정보 받아오기 API 요청
@@ -301,17 +306,27 @@ export class AuthService {
     try {
       response1 = await axios.get(apiUrl, { headers: header });
     } catch (error) {
-      throw new Error('네이버 토큰 발급 실패');
-    }
-
-    if (response1.status != 200){
-      throw new InternalServerErrorException(
-        '네이버 토큰 발급 실패(인증실패)',
+      throw new UnauthorizedException(
+        '유효하지 않거나 만료된 네이버 인가코드입니다.',
       );
     }
-    
+
+    if (response1.status != 200) {
+      throw new UnauthorizedException(
+        '유효하지 않거나 만료된 네이버 인가코드입니다.',
+      );
+    }
+
     // <-> Naver API / 토큰으로 사용자 정보 받아오기 API 요청
     const userToken = response1.data.access_token;
+
+    // 네이버는 인가코드가 무효여도 200을 주고 본문에 error를 담는다. 그대로 두면 access_token이 undefined인 채
+    // 사용자 정보 API를 호출해 엉뚱한 지점에서 터진다 — 여기서 인증 실패로 끊는다.
+    if (!userToken) {
+      throw new UnauthorizedException(
+        '유효하지 않거나 만료된 네이버 인가코드입니다.',
+      );
+    }
 
     const header2 = {
       Authorization: `Bearer ${userToken}`,
@@ -327,9 +342,11 @@ export class AuthService {
         },
       );
     } catch (error) {
-      throw new Error('네이버 토큰 발급 실패');
+      throw new UnauthorizedException(
+        '네이버 사용자 정보를 불러오지 못했습니다.',
+      );
     }
-    
+
     //사용자 정보가 DB에 존재하는지 확인(네이버 고유 id로 확인)
     const user = await this.userModel.findOne({
       naverId: String(response2.data.response.id),
@@ -408,14 +425,20 @@ export class AuthService {
 			Authorization: `Bearer ${dto.accessToken}`,
 		};
 
-		const response1: any = await axios
-			.get(`https://www.googleapis.com/oauth2/v3/userinfo`, { headers })
-			.catch((error) => {
-				console.log(error);
-			});
+    // 이전에는 .catch로 에러를 삼켜 response1이 undefined가 됐고, 바로 다음 줄의 response1.status에서
+    // TypeError가 나 500으로 떨어졌다. 액세스 토큰이 무효한 건 클라이언트 입력 문제이므로 401로 끊는다.
+    let response1: any;
 
-		if (response1.status != 200)
-			throw new Error("구글 사용자 정보를 불러올 수 없습니다.");
+    try {
+      response1 = await axios.get(
+        `https://www.googleapis.com/oauth2/v3/userinfo`,
+        { headers },
+      );
+    } catch (error) {
+      throw new UnauthorizedException(
+        '유효하지 않거나 만료된 구글 액세스 토큰입니다.',
+      );
+    }
 
     const user = await this.userModel.findOne({
       googleId: String(response1.data.sub),
@@ -502,9 +525,6 @@ export class AuthService {
 			complete: true,
 		});
 
-    console.log('decodedAppleIdToken')
-    console.log(decodedAppleIdToken)
-
     //클라이언트 공개 키 받아오기
 		const applePublicKeyResponse = await axios.get(`https://appleid.apple.com/auth/oauth2/v2/keys`);
 
@@ -526,12 +546,8 @@ export class AuthService {
         audience: 'com.ra-ising.raising',
       });
 		} catch (error) {
-			console.log(error);
-			throw new InternalServerErrorException("유효하지않은 애플 토큰입니다");
+			throw new UnauthorizedException('유효하지 않은 애플 토큰입니다.');
 		}
-
-    console.log('verifiedPayload')
-    console.log(verifiedPayload)
 
     //로그인 로직
     //사용자 정보가 DB에 존재하는지 확인(애플 고유 id로 확인)
@@ -581,7 +597,7 @@ export class AuthService {
 
       await this.updateUserRtHash(newUser.id, tokens.refreshToken);
 
-      return res.redirect(308, `https://ra-ising.com/oauth/apple?type=signUp&accessToken=${tokens.accessToken}&refreshToken=${tokens.refreshToken}`);
+      return this.redirectToWebOAuthCallback(res, 'signUp', tokens);
     } else {
       //존재하는 경우, 로그인 토큰 발급
       const tokens = await this.getUserTokens(
@@ -591,8 +607,38 @@ export class AuthService {
       );
       await this.updateUserRtHash(user.id, tokens.refreshToken);
 
-      return res.redirect(308, `https://ra-ising.com/oauth/apple?type=signIn&accessToken=${tokens.accessToken}&refreshToken=${tokens.refreshToken}`);
+      return this.redirectToWebOAuthCallback(res, 'signIn', tokens);
     }
+  }
+
+  /**
+   * 애플 로그인(form_post) 처리 후 웹 콜백 화면으로 돌려보낸다.
+   *
+   * 반드시 303(See Other)이어야 한다. 애플은 response_mode=form_post라 이 엔드포인트에 POST로 들어오는데,
+   * 308(또는 307)은 리다이렉트 시 **메서드를 그대로 보존**해서 브라우저가 /oauth/apple로 다시 POST를 보낸다.
+   * 웹은 SPA 정적 라우트라 nginx가 GET에만 index.html을 내주므로 그 POST는 404가 된다(실제로 그렇게 깨졌다).
+   * 303은 "POST는 처리했으니 이 URL을 GET해라"라는 의미라 브라우저가 GET으로 바꿔 따라온다 — form_post의 표준이다.
+   */
+  private redirectToWebOAuthCallback(
+    res: Response,
+    type: 'signIn' | 'signUp',
+    tokens: { accessToken: string; refreshToken: string },
+  ): void {
+    const params = new URLSearchParams({
+      type,
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+    });
+
+    return res.redirect(
+      HttpStatus.SEE_OTHER,
+      `${AuthService.getWebBaseUrl()}/oauth/apple?${params.toString()}`,
+    );
+  }
+
+  /** 웹 오리진. 하드코딩하면 스테이징·로컬 로그인이 프로덕션으로 튕겨나간다. */
+  private static getWebBaseUrl(): string {
+    return process.env.WEB_BASE_URL ?? 'https://ra-ising.com';
   }
 
   async withdrawal(user: JwtPayload): Promise<void> {


### PR DESCRIPTION
애플 로그인이 /oauth/apple 에서 404로 끝나던 문제.

애플은 response_mode=form_post 라 이 엔드포인트에 POST로 들어오는데, 처리 후 308로 리다이렉트하고 있었다. 308(과 307)은 리다이렉트 시 **HTTP 메서드를 그대로 보존**해서 브라우저가 /oauth/apple 로 다시 POST를 보낸다. 웹은 SPA 정적 라우트라 nginx가 GET에만 index.html을 내주므로 그 POST는 404가 된다. 303(See Other)은 "POST는 처리했으니 이 URL을 GET해라"라는 의미라 브라우저가 GET으로 바꿔 따라온다 — form_post 패턴의 표준이다. (토큰은 정상 발급되고 있었고 리다이렉트 상태코드만 틀렸다.)

함께 정리한 것:

- 리다이렉트 대상 URL이 https://ra-ising.com 으로 하드코딩돼 있어 스테이징·로컬 로그인이 프로덕션으로 튕겨나갔다. WEB_BASE_URL 환경변수로 빼되, 미설정 시 기존 값으로 폴백해 프로덕션은 그대로 동작한다.

- 클라이언트가 준 인가코드/토큰이 무효·만료·이미 사용된 경우에 500을 던지고 있었다. 서버 장애가 아닌데도 사용자에게 "Internal server error"가 그대로 노출되고 모니터링 알림도 오염된다. 401로 정리한다. (카카오/네이버/구글/애플 — 클라이언트의 401 인터셉터는 이미 /auth/signin·/auth/apple 을 리프레시 루프에서 제외하고 있어 안전하다.)

- 네이버는 인가코드가 무효여도 200을 주고 본문에 error를 담는다. access_token 이 undefined 인 채로 사용자 정보 API를 호출해 엉뚱한 지점에서 터지던 것을, 토큰 부재 검사로 인증 실패에서 끊는다.

- 구글은 .catch 가 에러를 삼켜 response1 이 undefined 가 되고 다음 줄 response1.status 에서 TypeError로 500이 났다. try/catch 로 바꿔 401로 끊는다.

- 애플 경로의 디버그 console.log 제거 — 디코딩된 페이로드에 사용자 이메일이 담겨 서버 로그로 샜다.

# PR
---
## Types
- [] Code Review
- [] New Feature
- [] Bug Fix
- [] CI/CD
- [] Setup
---
## Contents
### motivation

### changes

---
## To reviewer

---
## Footer

